### PR TITLE
#12: Fix footer appearing twice on press release details page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tylerlevsmusic",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "TylerLevsMusic web app",
   "author": "Gabor Meszaros <reklam11@gmail.com>",
   "repository": {

--- a/src/app/pages/press/press-releases/press-release-details/press-release-details.component.html
+++ b/src/app/pages/press/press-releases/press-release-details/press-release-details.component.html
@@ -52,4 +52,3 @@
     </div>
   </div>
 </section>
-<app-footer></app-footer>


### PR DESCRIPTION
Removed extra app-footer tag, as it's not needed anymore on individual pages

Resolves #12 