### PR TITLE
Minor fix for end date edit form

### DIFF
--- a/frontend/src/app/pages/admin/dashboard/dash-events/dash-events-edit-event-modal/dash-events-edit-event-modal.component.ts
+++ b/frontend/src/app/pages/admin/dashboard/dash-events/dash-events-edit-event-modal/dash-events-edit-event-modal.component.ts
@@ -68,7 +68,7 @@ export class DashEventsEditEventModalComponent implements OnInit {
     };
     if (this.event.endDate) {
       this.formEndDateEnabled = true;
-      const tzEndDate = moment.tz(this.event.date, 'America/New_York');
+      const tzEndDate = moment.tz(this.event.endDate, 'America/New_York');
       this.formEndDate = {
         year: tzEndDate.year(),
         month: tzEndDate.month() + 1,


### PR DESCRIPTION
Changed default end date to use the endDate from the event instead of the start date.