### PR TITLE
Allow legacy peer deps in api Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/node
 
 COPY . /home/node
 
-RUN npm ci \
+RUN npm ci --legacy-peer-deps \
     && npm run build \
     && npm prune --production
 


### PR DESCRIPTION
Allowed legacy peer deps because otherwise installing the latest version of class-validator would fail, and it is required to fix a critical vulnerability.