### PR TITLE
Fix class-validator dependency

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/node
 
 COPY . /home/node
 
-RUN npm ci --legacy-peer-deps \
+RUN npm ci \
     && npm run build \
     && npm prune --production
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2679,7 +2679,7 @@
       "peerDependencies": {
         "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
         "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
-        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0 || ^0.14.0",
         "reflect-metadata": "^0.1.12"
       },
       "peerDependenciesMeta": {


### PR DESCRIPTION
Temporary fix for class-validator dependency: added 0.14.0 to @nestjs/mapped-types peer dependencies in package-lock.json